### PR TITLE
update: pub use tracing_appender::non_blocking::WorkerGuard;

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 //! A convenient tracing config and init lib, with symlinking and local timezone.
 
 use time::macros::format_description;
-use tracing_appender::non_blocking::WorkerGuard;
+pub use tracing_appender::non_blocking::WorkerGuard;
 use tracing_subscriber::fmt;
 use tracing_subscriber::fmt::time::OffsetTime;
 


### PR DESCRIPTION
``` rust
fn init_log()->WorkerGuard{
    let guard = clia_tracing_config::build()
        .filter_level(&CFG.log.filter_level)
        .with_ansi(CFG.log.with_ansi)
        .to_stdout(CFG.log.to_stdout)
        .directory(&CFG.log.directory)
        .file_name(&CFG.log.file_name)
        .rolling(&CFG.log.rolling)
        .init();
    tracing::info!("log level: {}", &CFG.log.filter_level);
    guard
}
```
This allows you to return WorkerGuard directly without having to introduce the tracing_appender crate
